### PR TITLE
Simplify legion service

### DIFF
--- a/src/services/legionService.ts
+++ b/src/services/legionService.ts
@@ -19,80 +19,28 @@
 //     If not, see <http://www.gnu.org/licenses/>.
 
 import { invoke } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { listen } from '@tauri-apps/api/event';
 
-export interface ScanOptions {
-  targetIp: string;
-  scanType: string;
+/**
+ * Execute a scan plan by delegating to the backend engine.
+ */
+export async function engineExecute(plan: any): Promise<void> {
+  await invoke('engine_execute', { plan });
 }
 
-export interface ScanProgressEvent {
-  scanId: string;
-  progress: number;
-  message?: string;
+/**
+ * Subscribe to observation events emitted by the backend.
+ * Returns an unsubscribe function to remove all listeners.
+ */
+export async function subscribeObs(
+  onHost: (data: any) => void,
+  onService: (data: any) => void,
+  onMetric: (data: any) => void
+): Promise<() => void> {
+  const unsubs: Array<() => void> = [];
+  unsubs.push(await listen('obs:service', (e) => onService(e.payload)));
+  unsubs.push(await listen('obs:host', (e) => onHost(e.payload)));
+  unsubs.push(await listen('obs:metric', (e) => onMetric(e.payload)));
+  return () => unsubs.forEach((u) => u());
 }
 
-export interface VulnerabilityResult {
-  id: string;
-  severity: string;
-  description: string;
-  port?: number;
-  service?: string;
-}
-
-export interface TauriLegionService {
-  startScan(options: ScanOptions): Promise<string>;
-  stopScan(scanId: string): Promise<void>;
-  getVulnerabilities(severityFilter?: string): Promise<VulnerabilityResult[]>;
-  onScanProgress(scanId: string, callback: (progress: ScanProgressEvent) => void): Promise<UnlistenFn>;
-  removeScanListener(scanId: string): Promise<void>;
-  isScanning(): Promise<boolean>;
-}
-
-class TauriLegionServiceImpl implements TauriLegionService {
-  private scanListeners: Map<string, UnlistenFn> = new Map();
-
-  async startScan(options: ScanOptions): Promise<string> {
-    // Send as single options object
-    const scanId = await invoke<string>('start_scan', { options });
-    return scanId;
-  }
-
-  async stopScan(scanId: string): Promise<void> {
-    await invoke('stop_scan', { scanId });
-  }
-
-  async getVulnerabilities(severityFilter?: string): Promise<VulnerabilityResult[]> {
-    // Handle optional parameter
-    const args = severityFilter ? { severityFilter } : {};
-    return await invoke<VulnerabilityResult[]>('get_vulnerabilities', args);
-  }
-
-  async onScanProgress(scanId: string, callback: (progress: ScanProgressEvent) => void): Promise<UnlistenFn> {
-    // Listen to scan-specific progress events
-    const eventName = `scan-progress-${scanId}`;
-    const unlisten = await listen<ScanProgressEvent>(eventName, (event) => {
-      callback(event.payload);
-    });
-    
-    // Store the unlisten function
-    this.scanListeners.set(scanId, unlisten);
-    
-    return unlisten;
-  }
-
-  async removeScanListener(scanId: string): Promise<void> {
-    const unlisten = this.scanListeners.get(scanId);
-    if (unlisten) {
-      unlisten();
-      this.scanListeners.delete(scanId);
-    }
-  }
-
-  async isScanning(): Promise<boolean> {
-    return await invoke<boolean>('is_scanning');
-  }
-}
-
-// Export singleton instance
-export const legionService: TauriLegionService = new TauriLegionServiceImpl();


### PR DESCRIPTION
## Summary
- streamline legionService to only invoke `engine_execute` and listen to `obs:*` events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: src/components/ResultViewer.tsx(33,9): error TS6198: All destructured elements are unused.)*

------
https://chatgpt.com/codex/tasks/task_e_689e226f82b8832abcd07e8b6961e671