### PR TITLE
Refactor scan invocation and remove manual tracking

### DIFF
--- a/src/components/ResultViewer.tsx
+++ b/src/components/ResultViewer.tsx
@@ -20,7 +20,6 @@
 
 import React, { useState, useMemo } from 'react';
 import { Shield, AlertTriangle, Download, Search } from 'lucide-react';
-import useAppStore from '../stores/appStore';
 import { Host } from '../types/scanning';
 
 interface ResultViewerProps {
@@ -30,11 +29,9 @@ interface ResultViewerProps {
 }
 
 const ResultViewer: React.FC<ResultViewerProps> = ({ selectedScanId }) => {
-  const { recentHosts, metrics } = useAppStore();
-  
   // Mock scan data for now since we're using a simplified store
   const scanHistory: any[] = [];
-  const getScanById = (id: string) => null;
+  const getScanById = (_id: string) => null;
   
   const [selectedTab, setSelectedTab] = useState<'ports' | 'vulnerabilities' | 'details'>('ports');
   const [severityFilter, setSeverityFilter] = useState<string>('all');

--- a/src/components/ScanProgress.tsx
+++ b/src/components/ScanProgress.tsx
@@ -68,20 +68,8 @@ const ScanProgress: React.FC<ScanProgressProps> = ({
   // Your existing store data (always available)
   const {
     scanInProgress: storeIsScanning,
-    activeScans: storeActiveScans,
-    metrics: storeMetrics,
-    cancelScan: storeCancelScan
+    metrics: storeMetrics
   } = useAppStore();
-  
-  // Mock data for compatibility
-  const storeProgress = new Map();
-  const storeStatistics = {
-    total_scans: 0,
-    active_scans: storeActiveScans.size,
-    total_hosts_discovered: storeMetrics.hosts_discovered,
-    total_vulnerabilities: 0
-  };
-  const storeCancelAllScans = () => {};
 
   // Backend data (may not be available initially)
   const [backendProgress, setBackendProgress] = useState<Map<string, BackendScanProgress>>(new Map());
@@ -95,11 +83,17 @@ const ScanProgress: React.FC<ScanProgressProps> = ({
     // 1. Try Backend Data First
     if (backendProgress.size > 0 || backendStats) {
       console.log('🔄 Using BACKEND data (real-time from Tauri API)');
+      const stats = backendStats ?? {
+        total_scans: 0,
+        active_scans: 0,
+        total_hosts_discovered: storeMetrics.hosts_discovered,
+        total_vulnerabilities: 0
+      };
       return {
         activeScans: Array.from(backendProgress.values()).map(progress => ({
           id: progress.scan_id,
           target_id: progress.current_target || 'Unknown',
-          status: progress.progress === 100 ? 'completed' : 
+          status: progress.progress === 100 ? 'completed' :
                   progress.current_phase === 'Failed' ? 'failed' :
                   progress.current_phase === 'Cancelled' ? 'cancelled' : 'running',
           start_time: progress.start_time,
@@ -109,34 +103,23 @@ const ScanProgress: React.FC<ScanProgressProps> = ({
           error_message: progress.current_phase === 'Failed' ? progress.message : undefined
         } as ScanResult)),
         progress: backendProgress,
-        statistics: backendStats || storeStatistics,
+        statistics: stats,
         isScanning: isBackendScanning
       };
     }
-    
-    // 2. Fallback to Store Data
-    if (storeActiveScans.size > 0) {
-      console.log('📦 Using STORE data (fallback from useScanStore)');
-      return {
-        activeScans: Array.from(storeActiveScans.values()),
-        progress: storeProgress,
-        statistics: storeStatistics,
-        isScanning: storeIsScanning
-      };
-    }
-    
-    // 3. Safe Defaults
+
+    // 2. Safe Defaults
     console.log('🔧 Using DEFAULT data (safe fallbacks)');
     return {
       activeScans: [],
       progress: new Map(),
       statistics: {
         total_scans: 0,
-        active_scans: 0,
-        total_hosts_discovered: 0,
+        active_scans: storeIsScanning ? 1 : 0,
+        total_hosts_discovered: storeMetrics.hosts_discovered,
         total_vulnerabilities: 0
       } as ScanStatistics,
-      isScanning: false
+      isScanning: storeIsScanning
     };
   };
 
@@ -209,21 +192,15 @@ const ScanProgress: React.FC<ScanProgressProps> = ({
     });
   };
 
-  // Enhanced cancel functions that try backend first, then store
+  // Cancel functions rely solely on backend
   const cancelScan = async (scanId: string) => {
     try {
-      // Try backend first
       if (scanAPI?.cancelNetworkScan) {
         await scanAPI.cancelNetworkScan(scanId);
       }
-      // Also update store as fallback
-      storeCancelScan(scanId);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to cancel scan';
       setBackendError(errorMessage);
-      // Try store cancellation as backup
-      storeCancelScan(scanId);
-      
       if (onError) {
         onError(errorMessage);
       }
@@ -232,24 +209,17 @@ const ScanProgress: React.FC<ScanProgressProps> = ({
 
   const cancelAllScans = async () => {
     try {
-      // Try backend first
       if (scanAPI?.cancelNetworkScan) {
-        const promises = Array.from(backendProgress.keys()).map(scanId => 
+        const promises = Array.from(backendProgress.keys()).map(scanId =>
           scanAPI.cancelNetworkScan(scanId)
         );
         await Promise.all(promises);
       }
       setBackendProgress(new Map());
       setIsBackendScanning(false);
-      
-      // Also update store
-      storeCancelAllScans();
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to cancel scans';
       setBackendError(errorMessage);
-      // Try store cancellation as backup
-      storeCancelAllScans();
-      
       if (onError) {
         onError(errorMessage);
       }
@@ -301,7 +271,7 @@ const ScanProgress: React.FC<ScanProgressProps> = ({
           Scan Progress
           {/* Data Source Indicator */}
           <span className="text-xs px-2 py-1 rounded bg-gray-700 text-gray-300">
-            {backendProgress.size > 0 ? '🔄 Live' : '📦 Store'}
+            {backendProgress.size > 0 ? '🔄 Live' : '⏸ Idle'}
           </span>
         </h2>
         

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -23,9 +23,6 @@ import type { ScanConfig } from '../types/scanning';
 
 // Simple state reflecting backend events
 interface AppState {
-  // Current active scans (from engine_execute calls)
-  activeScans: Set<string>;
-
   // Live data from UiSink events
   recentHosts: Array<{ ip: string; hostname?: string; timestamp: string }>;
   recentServices: Array<{ ip: string; port: number; protocol: string; timestamp: string }>;
@@ -46,7 +43,6 @@ interface AppState {
 interface AppActions {
   // Simple actions
   startScan: (config: ScanConfig) => Promise<void>;
-  cancelScan: (scanId: string) => Promise<void>;
   clearOutput: () => void;
 }
 
@@ -97,7 +93,6 @@ const useAppStore = create<AppState & AppActions>((set) => {
 
   return {
     // Initial state
-    activeScans: new Set(),
     recentHosts: [],
     recentServices: [],
     liveOutput: [],
@@ -111,8 +106,9 @@ const useAppStore = create<AppState & AppActions>((set) => {
 
     // Actions
     startScan: async (config: ScanConfig) => {
-      // Convert frontend ScanConfig to backend ScanConfig format
-      const backendConfig = {
+      // Build execution plan from frontend ScanConfig
+      const plan = {
+        scan_id: crypto.randomUUID(),
         targets: config.targets,
         scan_type: config.scanType || 'comprehensive',
         ports: config.ports || undefined,
@@ -122,29 +118,13 @@ const useAppStore = create<AppState & AppActions>((set) => {
         modules: [], // Could be populated from frontend later
       };
 
-      set(state => ({
+      set(() => ({
         scanInProgress: true,
-        liveOutput: [`Starting ${backendConfig.use_masscan ? 'masscan' : 'nmap'} scan for ${backendConfig.targets}...`]
+        liveOutput: [`Starting ${plan.use_masscan ? 'masscan' : 'nmap'} scan for ${plan.targets}...`]
       }));
 
-      // Use the new command that leverages Plan builders
-      const scanId = await invoke('start_scan_with_config', { config: backendConfig }) as string;
-      
-      set(state => ({
-        activeScans: new Set([...state.activeScans, scanId])
-      }));
-    },
-
-    cancelScan: async (scanId: string) => {
-      await invoke('cancel_scan', { scan_id: scanId });
-      set(state => {
-        const newScans = new Set(state.activeScans);
-        newScans.delete(scanId);
-        return {
-          activeScans: newScans,
-          scanInProgress: newScans.size > 0
-        };
-      });
+      // Execute plan via engine
+      await invoke('engine_execute', { plan });
     },
 
     clearOutput: () => {


### PR DESCRIPTION
## Summary
- invoke `engine_execute` with generated plan when starting scans
- simplify store and progress components to rely on event-driven updates rather than manual tracking
- clean up unused result viewer imports to satisfy type checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e225f6480832ab4e29763bd26e285