### PR TITLE
feat: add scanAPI object and update ScanProgress component

### DIFF
--- a/src/components/ScanProgress.tsx
+++ b/src/components/ScanProgress.tsx
@@ -1,0 +1,73 @@
+// LEGION2 - A free and open-source penetration testing tool.
+// Copyright (c) 2025 NubleX / Igor Dunaev
+
+// Forked from an earlier version of LEGION, which was originally created by Gotham Security.
+// It was archived in 2024.
+
+// LEGION (https://gotham-security.com)
+// Copyright (c) 2023 Gotham Security
+
+//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+//     License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+//     version.
+
+//     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+//     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//     details.
+
+//     You should have received a copy of the GNU General Public License along with this program.
+//     If not, see <http://www.gnu.org/licenses/>.
+
+import React, { useEffect, useState } from 'react';
+import { scanAPI } from '../services/tauriApi';
+
+interface ScanProgressProps {
+  scanId: string;
+}
+
+const ScanProgress: React.FC<ScanProgressProps> = ({ scanId }) => {
+  const [progress, setProgress] = useState<any>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const p = await scanAPI.getScanProgress(scanId);
+        if (!cancelled) {
+          setProgress(p);
+          if (await scanAPI.isScanning()) {
+            setTimeout(poll, 1000);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to fetch scan progress', err);
+      }
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [scanId]);
+
+  const handleCancel = () => {
+    scanAPI.cancelNetworkScan(scanId).catch(console.error);
+  };
+
+  if (!progress) {
+    return <div>Loading progress...</div>;
+  }
+
+  return (
+    <div>
+      <div>{progress.stage}</div>
+      <div>{progress.percentage}%</div>
+      <button onClick={handleCancel}>Cancel</button>
+    </div>
+  );
+};
+
+export default ScanProgress;
+

--- a/src/services/tauriApi.ts
+++ b/src/services/tauriApi.ts
@@ -21,7 +21,7 @@ import { listen } from '@tauri-apps/api/event';
 /**
  * Execute a scan plan via the backend engine.
  */
-export async function startScan(targets: string, ports: string, rate = 5000) {
+async function startScan(targets: string, ports: string, rate = 5000) {
   const plan = {
     scan_id: crypto.randomUUID(),
     targets,
@@ -34,10 +34,41 @@ export async function startScan(targets: string, ports: string, rate = 5000) {
 }
 
 /**
+ * Get the current progress for an active scan.
+ */
+async function getScanProgress(scanId: string) {
+  const result = await invoke<string>('get_scan_progress', { scanId });
+  return JSON.parse(result);
+}
+
+/**
+ * Retrieve aggregated scan statistics from the backend.
+ */
+async function getScanStatistics() {
+  const result = await invoke<string>('get_scan_statistics');
+  return JSON.parse(result);
+}
+
+/**
+ * Check if any network scans are currently running.
+ */
+async function isScanning() {
+  const active = await invoke<string[]>('get_active_scans');
+  return active.length > 0;
+}
+
+/**
+ * Cancel an active network scan.
+ */
+async function cancelNetworkScan(scanId: string) {
+  await invoke('cancel_scan', { scanId });
+}
+
+/**
  * Subscribe to observation events emitted by the backend.
  * Returns a function to unsubscribe all listeners.
  */
-export async function subscribeObs(
+async function subscribeObs(
   onHost: (o: any) => void,
   onService: (o: any) => void,
   onLog: (o: any) => void,
@@ -48,3 +79,12 @@ export async function subscribeObs(
   unsubs.push(await listen('obs:metric', (e) => onLog(e.payload)));
   return () => unsubs.forEach((u) => u());
 }
+
+export const scanAPI = {
+  startScan,
+  getScanProgress,
+  getScanStatistics,
+  isScanning,
+  cancelNetworkScan,
+  subscribeObs,
+};


### PR DESCRIPTION
## Summary
- centralize scan interactions in new `scanAPI` helper
- poll and cancel scans via new `ScanProgress` component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e349b25b8832ab1b03bceaf804cb1