### PR TITLE
feat: integrate optional masscan pre-scan

### DIFF
--- a/src-tauri/src/commands/scanner_commands.rs
+++ b/src-tauri/src/commands/scanner_commands.rs
@@ -57,6 +57,7 @@ pub struct ScanOptions {
     pub ports: Option<String>,
     pub rate: Option<u32>,
     pub extra_args: Option<Vec<String>>,
+    pub use_masscan: Option<bool>,
 }
 
 #[tauri::command]
@@ -68,9 +69,15 @@ pub async fn start_scan<R: Runtime>(
     // Convert the request into a ScanTarget
     let target = ScanTarget::from_string(&request.target).map_err(|e| e.to_string())?;
 
+    let use_masscan = request
+        .options
+        .as_ref()
+        .and_then(|o| o.use_masscan)
+        .unwrap_or(false);
+
     // Start the scan using the coordinator
     let scan_id = coordinator
-        .start_scan(target)
+        .start_scan(target, use_masscan)
         .await
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/scanning/coordinator.rs
+++ b/src-tauri/src/scanning/coordinator.rs
@@ -67,7 +67,7 @@ impl ScanCoordinator {
         }
     }
 
-    pub async fn start_scan(&self, target: ScanTarget) -> Result<Uuid> {
+    pub async fn start_scan(&self, target: ScanTarget, use_masscan: bool) -> Result<Uuid> {
         let scan_id = Uuid::new_v4();
         log::info!(
             "Starting scan for target: {:?} with ID: {}",
@@ -82,7 +82,8 @@ impl ScanCoordinator {
         self.initialize_scan(scan_id, &target, cancel_tx).await?;
 
         // Spawn scan task
-        self.spawn_scan_task(scan_id, target.clone(), cancel_rx, progress_tx)
+        self
+            .spawn_scan_task(scan_id, target.clone(), cancel_rx, progress_tx, use_masscan)
             .await;
 
         // Monitor progress
@@ -117,8 +118,10 @@ impl ScanCoordinator {
         target: ScanTarget,
         mut cancel_rx: mpsc::Receiver<()>,
         progress_tx: mpsc::Sender<ScanProgress>,
+        use_masscan: bool,
     ) {
-        let scanner = self.nmap_scanner.clone();
+        let nmap_scanner = self.nmap_scanner.clone();
+        let masscan_scanner = self.masscan_scanner.clone();
         let active_scans = self.active_scans.clone();
         let results_tx = self.results_tx.clone();
         let database = self.database.clone();
@@ -129,7 +132,28 @@ impl ScanCoordinator {
                     log::info!("Scan {} cancelled", scan_id);
                     Err(anyhow::anyhow!("Scan cancelled"))
                 }
-                scan_result = scanner.scan_target(&target, progress_tx, Some(results_tx.clone())) => {
+                scan_result = async {
+                    let mut target = target;
+                    if use_masscan {
+                        let progress_clone = progress_tx.clone();
+                        match masscan_scanner
+                            .scan_target(&target, progress_clone, results_tx.clone())
+                            .await
+                        {
+                            Ok(ports) => {
+                                if !ports.is_empty() {
+                                    target.ports = Some(ports);
+                                }
+                            }
+                            Err(e) => {
+                                log::error!("Masscan failed for {}: {}", target.ip, e);
+                            }
+                        }
+                    }
+                    nmap_scanner
+                        .scan_target(&target, progress_tx, Some(results_tx.clone()))
+                        .await
+                } => {
                     scan_result
                 }
             };
@@ -202,7 +226,7 @@ impl ScanCoordinator {
                 scan_type: scan_type.clone(),
             };
 
-            match self.start_scan(target).await {
+            match self.start_scan(target, false).await {
                 Ok(scan_id) => {
                     scan_ids.push(scan_id);
 

--- a/src-tauri/src/scanning/masscan.rs
+++ b/src-tauri/src/scanning/masscan.rs
@@ -11,10 +11,15 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
+use crate::commands::scanner_commands::ScanTarget;
 use crate::core::traits::Source;
 use crate::plan::Plan;
-use crate::scanning::models::ScanProgress;
+use crate::scanning::events::{EventType, ScanEvent};
+use crate::scanning::models::{ScanProgress, ScanStatus};
 use crate::shared::{ObsStream, Observation, ObservationKind};
+use serde_json::json;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MasscanOptions {
@@ -68,6 +73,128 @@ impl MasscanScanner {
             .await
             .map(|output| output.status.success())
             .unwrap_or(false)
+    }
+
+    pub async fn scan_target(
+        &self,
+        target: &ScanTarget,
+        progress_tx: mpsc::Sender<ScanProgress>,
+        event_tx: mpsc::Sender<ScanEvent>,
+    ) -> Result<Vec<u16>> {
+        if !self.check_masscan_available().await {
+            return Err(anyhow!("masscan binary not found. Please install masscan."));
+        }
+
+        let ports_arg = if let Some(ports) = &target.ports {
+            ports.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(",")
+        } else {
+            "1-65535".to_string()
+        };
+
+        let mut cmd = Command::new(&self.bin);
+        cmd.arg("-p")
+            .arg(&ports_arg)
+            .arg(target.ip.to_string())
+            .args(["--open", "--wait", "0"])
+            .arg("--rate")
+            .arg(self.options.rate.to_string())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+
+        let mut child = cmd.spawn()?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Failed to get stdout"))?;
+        let mut lines = BufReader::new(stdout).lines();
+
+        let mut open_ports = Vec::new();
+        let now = Utc::now();
+        let _ = progress_tx
+            .send(ScanProgress {
+                scan_id: target.id.clone(),
+                status: ScanStatus::Running,
+                percentage: 0.0,
+                stage: "Masscan".to_string(),
+                targets_completed: 0,
+                targets_total: 1,
+                hosts_found: 0,
+                services_found: 0,
+                eta_seconds: None,
+                started_at: now,
+                updated_at: now,
+                rate: None,
+                details: HashMap::new(),
+                progress: 0.0,
+                current_target: Some(target.ip.to_string()),
+                hosts_discovered: 0,
+                ports_found: 0,
+                vulnerabilities: 0,
+                elapsed_time: 0,
+                estimated_remaining: None,
+                message: Some("Starting masscan".to_string()),
+                start_time: now,
+                current_phase: "Masscan".to_string(),
+            })
+            .await;
+
+        let scan_uuid = uuid::Uuid::parse_str(&target.id)?;
+        while let Some(line) = lines.next_line().await? {
+            if let Some(obs) = parse_masscan_line(&line, scan_uuid) {
+                if let Some(port_val) = obs.fields.get("port").and_then(|v| v.as_u64()) {
+                    open_ports.push(port_val as u16);
+                    let _ = event_tx
+                        .send(ScanEvent {
+                            scan_id: target.id.clone(),
+                            event_type: EventType::ServiceDiscovered,
+                            timestamp: Utc::now(),
+                            data: json!({
+                                "ip": target.ip.to_string(),
+                                "port": port_val,
+                                "protocol": obs
+                                    .fields
+                                    .get("protocol")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("tcp"),
+                            }),
+                        })
+                        .await;
+                }
+            }
+        }
+
+        let _ = child.wait().await?;
+
+        let now = Utc::now();
+        let _ = progress_tx
+            .send(ScanProgress {
+                scan_id: target.id.clone(),
+                status: ScanStatus::Running,
+                percentage: 100.0,
+                stage: "Masscan".to_string(),
+                targets_completed: 1,
+                targets_total: 1,
+                hosts_found: 0,
+                services_found: open_ports.len(),
+                eta_seconds: None,
+                started_at: now,
+                updated_at: now,
+                rate: None,
+                details: HashMap::new(),
+                progress: 100.0,
+                current_target: Some(target.ip.to_string()),
+                hosts_discovered: 0,
+                ports_found: open_ports.len() as u32,
+                vulnerabilities: 0,
+                elapsed_time: 0,
+                estimated_remaining: None,
+                message: Some("Masscan completed".to_string()),
+                start_time: now,
+                current_phase: "Masscan".to_string(),
+            })
+            .await;
+
+        Ok(open_ports)
     }
 }
 


### PR DESCRIPTION
## Summary
- allow front-end to request masscan pre-scan via `use_masscan` flag
- run masscan to discover ports before nmap scan when requested
- pipe masscan progress and results through existing channels

## Testing
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `pytest` *(fails: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_689e34a50908832a9d251cc738ea10d8