### PR TITLE
Trigger incremental analysis after DB inserts

### DIFF
--- a/src-tauri/src/core/registry.rs
+++ b/src-tauri/src/core/registry.rs
@@ -2,31 +2,35 @@
 //      mk_transform: Box<dyn Fn(&str) -> Result<Box<dyn Transform>> + Send + Sync>, 
 //      mk_sink: Box<dyn Fn(&str) -> Result<Box<dyn Sink>> + Send + Sync>,
 
-use anyhow::{Result, anyhow};
-use tauri::AppHandle;
-use std::sync::Arc;
+use anyhow::{anyhow, Result};
 use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::AppHandle;
 
-use super::traits::{Sink, Source};
-use crate::plan::Plan;
-use super::sinks::{UiSink, DbSink};
+use crate::analysis::AnalysisEngine;
 use crate::database::Db;
+use crate::plan::Plan;
 use crate::scanning::masscan::MasscanScanner;
 use crate::scanning::nmap::NmapScanner;
+use super::sinks::{DbSink, UiSink};
+use super::traits::{Sink, Source};
 
 /// Registry for managing scanning components and their lifecycle
 pub struct Registry {
     db: Arc<Db>,
     app_handle: AppHandle,
+    analysis_engine: Arc<AnalysisEngine>,
     sources: HashMap<String, Box<dyn Source>>,
     sinks: HashMap<String, Box<dyn Sink>>,
 }
 
 impl Registry {
     pub fn new(db: Arc<Db>, app_handle: AppHandle) -> Self {
-        Self { 
+        let analysis_engine = Arc::new(AnalysisEngine::with_ui(db.clone(), app_handle.clone()));
+        Self {
             db,
             app_handle,
+            analysis_engine,
             sources: HashMap::new(),
             sinks: HashMap::new(),
         }
@@ -54,7 +58,7 @@ impl Registry {
         for sink_type in &plan.sink_types {
             match sink_type.as_str() {
                 "ui" => sinks.push(Box::new(UiSink::new(self.app_handle.clone())) as Box<dyn Sink>),
-                "db" => sinks.push(Box::new(DbSink::new(self.db.clone())) as Box<dyn Sink>),
+                "db" => sinks.push(Box::new(DbSink::new(self.db.clone(), self.analysis_engine.clone())) as Box<dyn Sink>),
                 _ => log::warn!("Unknown sink type: {}, skipping", sink_type),
             }
         }

--- a/src-tauri/src/core/sinks.rs
+++ b/src-tauri/src/core/sinks.rs
@@ -1,17 +1,20 @@
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
+
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::{Serialize, Deserialize};
-use tauri::{AppHandle, Emitter};
-use futures::StreamExt;
 use chrono::Utc;
-use tokio::time::{Duration, interval};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
+use tokio::time::{interval, Duration};
 
+use crate::analysis::AnalysisEngine;
 use crate::core::traits::Sink;
-use crate::shared::{ObservationKind, ObsStream};
 use crate::database::Db;
+use crate::shared::{ObservationKind, ObsStream};
 
 // Event structures for frontend communication
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -332,15 +335,17 @@ impl ObsBatch {
 /// DbSink stores observations in the database with batching for performance
 pub struct DbSink {
     pub db: Arc<Db>,
+    analysis_engine: Arc<AnalysisEngine>,
     batch_size: usize,
     flush_interval: Duration,
     metrics: SinkMetrics,
 }
 
 impl DbSink {
-    pub fn new(db: Arc<Db>) -> Self {
-        Self { 
+    pub fn new(db: Arc<Db>, analysis_engine: Arc<AnalysisEngine>) -> Self {
+        Self {
             db,
+            analysis_engine,
             batch_size: 100, // Process 100 observations at a time
             flush_interval: Duration::from_secs(5), // Flush every 5 seconds
             metrics: SinkMetrics::new(),
@@ -348,9 +353,15 @@ impl DbSink {
     }
 
     /// Create a new DbSink with custom batch configuration
-    pub fn with_config(db: Arc<Db>, batch_size: usize, flush_interval: Duration) -> Self {
+    pub fn with_config(
+        db: Arc<Db>,
+        analysis_engine: Arc<AnalysisEngine>,
+        batch_size: usize,
+        flush_interval: Duration,
+    ) -> Self {
         Self {
             db,
+            analysis_engine,
             batch_size,
             flush_interval,
             metrics: SinkMetrics::new(),
@@ -390,6 +401,19 @@ impl DbSink {
             self.metrics.increment_errors().await;
         } else {
             self.metrics.increment_hosts().await;
+
+            let data = json!({ "hostname": hostname });
+            if let Err(e) = self
+                .analysis_engine
+                .trigger_incremental_analysis("host", ip, &data)
+                .await
+            {
+                log::error!(
+                    "Failed to trigger incremental analysis for host {}: {}",
+                    ip, e
+                );
+                self.metrics.increment_errors().await;
+            }
         }
         Ok(())
     }
@@ -400,11 +424,34 @@ impl DbSink {
         
         // Use the existing Db.upsert_service method
         let reason_opt = if reason.is_empty() { None } else { Some(reason) };
-        if let Err(e) = self.db.upsert_service(ip, port, protocol, reason_opt, Utc::now()) {
-            log::error!("Failed to upsert service {}:{}/{}: {}", ip, port, protocol, e);
+        if let Err(e) = self
+            .db
+            .upsert_service(ip, port, protocol, reason_opt, Utc::now())
+        {
+            log::error!(
+                "Failed to upsert service {}:{}/{}: {}",
+                ip, port, protocol, e
+            );
             self.metrics.increment_errors().await;
         } else {
             self.metrics.increment_services().await;
+
+            let data = json!({
+                "port": port,
+                "protocol": protocol,
+                "reason": reason,
+            });
+            if let Err(e) = self
+                .analysis_engine
+                .trigger_incremental_analysis("service", ip, &data)
+                .await
+            {
+                log::error!(
+                    "Failed to trigger incremental analysis for service {}:{}/{}: {}",
+                    ip, port, protocol, e
+                );
+                self.metrics.increment_errors().await;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- propagate scan results to AnalysisEngine via DbSink and Registry
- run incremental analysis after host/service inserts

## Testing
- `cargo test` *(fails: gobject-2.0 and glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e45156160832a8b507979e3228641