### PR TITLE
feat(ui): show vendor info for hosts

### DIFF
--- a/src/components/HostTable.tsx
+++ b/src/components/HostTable.tsx
@@ -64,6 +64,7 @@ const HostTable: React.FC<HostTableProps> = ({ onHostSelect, className = '' }) =
             <tr className="text-left text-gray-400 border-b border-gray-700">
               <th className="px-3 py-2">IP Address</th>
               <th className="px-3 py-2">Hostname</th>
+              <th className="px-3 py-2">Vendor</th>
               <th className="px-3 py-2">OS</th>
               <th className="px-3 py-2">Ports</th>
               <th className="px-3 py-2">Vulns</th>
@@ -86,6 +87,11 @@ const HostTable: React.FC<HostTableProps> = ({ onHostSelect, className = '' }) =
                 <td className="px-3 py-2">
                   <span className="text-gray-300">
                     {host.hostname || '-'}
+                  </span>
+                </td>
+                <td className="px-3 py-2">
+                  <span className="text-gray-300">
+                    {host.vendor || '-'}
                   </span>
                 </td>
                 <td className="px-3 py-2">
@@ -121,7 +127,7 @@ const HostTable: React.FC<HostTableProps> = ({ onHostSelect, className = '' }) =
             ))}
             {hosts.length === 0 && (
               <tr>
-                <td className="px-3 py-8 text-center text-gray-400" colSpan={6}>
+                <td className="px-3 py-8 text-center text-gray-400" colSpan={7}>
                   No hosts found
                 </td>
               </tr>

--- a/src/components/ResultViewer.tsx
+++ b/src/components/ResultViewer.tsx
@@ -339,10 +339,15 @@ const ResultViewer: React.FC<ResultViewerProps> = ({ selectedScanId, selectedHos
                     <span className="text-gray-400">IP Address</span>
                     <span className="font-mono text-white">{currentHost.ip}</span>
                   </div>
-                  
+
                   <div className="flex justify-between py-2 border-b border-gray-700">
                     <span className="text-gray-400">Hostname</span>
                     <span className="text-white">{currentHost.hostname || 'Unknown'}</span>
+                  </div>
+
+                  <div className="flex justify-between py-2 border-b border-gray-700">
+                    <span className="text-gray-400">Vendor</span>
+                    <span className="text-white">{currentHost.vendor || 'Unknown'}</span>
                   </div>
 
                   <div className="flex justify-between py-2 border-b border-gray-700">
@@ -355,11 +360,6 @@ const ResultViewer: React.FC<ResultViewerProps> = ({ selectedScanId, selectedHos
                   <div className="flex justify-between py-2 border-b border-gray-700">
                     <span className="text-gray-400">MAC Address</span>
                     <span className="font-mono text-white">{currentHost.mac_address || 'Unknown'}</span>
-                  </div>
-
-                  <div className="flex justify-between py-2 border-b border-gray-700">
-                    <span className="text-gray-400">Vendor</span>
-                    <span className="text-white">{currentHost.vendor || 'Unknown'}</span>
                   </div>
 
                   <div className="flex justify-between py-2 border-b border-gray-700">

--- a/src/stores/hostStore.ts
+++ b/src/stores/hostStore.ts
@@ -56,11 +56,16 @@ const useHostStore = create<HostStore>((set, get) => {
   listen('obs:host', (event: any) => {
     const hostEvent = event.payload;
     console.log('Received obs:host event:', hostEvent);
-    
+
     // Convert basic HostEvent to partial Host object
     const partialHost: Partial<Host> = {
       ip: hostEvent.ip,
       hostname: hostEvent.hostname,
+      mac_address: hostEvent.mac_address,
+      vendor: hostEvent.vendor,
+      os_name: hostEvent.os_name,
+      os_family: hostEvent.os_family,
+      os_accuracy: hostEvent.os_accuracy,
       id: hostEvent.ip, // Use IP as temporary ID
       status: 'up', // Assume host is up if discovered
       created_at: hostEvent.timestamp,


### PR DESCRIPTION
## Summary
- propagate vendor and other host details from events
- display vendor column in host table and move vendor higher in host details

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd src-tauri && cargo test` *(fails: could not find system library `glib-2.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68a39137df0c832aa3c4c62a41e6ca3a