### PR TITLE
docs: beta status badge, third-party licenses, ignore release binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ src-tauri/.logs/*
 src-tauri/gen/schemas/*
 src-tauri/claude/*
 src-tauri/.scans/*
+
+# release artifacts (publish via GitHub Releases, not git)
+releases/
+*.AppImage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Version](https://img.shields.io/badge/version-0.4.0-red.svg)
 ![Platform](https://img.shields.io/badge/platform-Linux-lightgrey.svg)
 ![Language](https://img.shields.io/badge/language-Rust%20%2B%20TypeScript-orange.svg)
-![Status](https://img.shields.io/badge/status-alpha--development-orange.svg)
+![Status](https://img.shields.io/badge/status-beta-orange.svg)
 
 ### Version: 0.4.0
 

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -1,15 +1,17 @@
 # Third Party Software Licenses
 
-LEGION2 includes and/or distributes the following third-party software components. We are grateful to the developers of these tools for making them available under open source licenses.
+LEGION2 currently invokes the following third-party scanning tools as external dependencies. We are grateful to the developers of these tools for making them available under open source licenses.
+
+> **Roadmap:** Native Rust replacements for nmap and masscan are in development (`nmap_stream.rs`, `masscan_stream.rs`). Once complete, LEGION2 will no longer bundle or depend on GPL-2.0/AGPL-3.0 binaries for core scanning.
 
 ## Nmap Network Mapper
 
-**Version**: 7.94  
+**Version**: 7.94+ (system package or official binary)  
 **License**: GPL-2.0 (GNU General Public License v2.0)  
 **Website**: https://nmap.org  
 **Source Code**: https://github.com/nmap/nmap  
 
-**Description**: Nmap ("Network Mapper") is a free and open source utility for network discovery and security auditing. Many systems and network administrators also find it useful for tasks such as network inventory, managing service upgrade schedules, and monitoring host or service uptime.
+**Description**: Nmap ("Network Mapper") is a free and open source utility for network discovery and security auditing. LEGION2 orchestrates nmap for host discovery, service detection, and NSE scripts.
 
 **License Text**: The full text of the GPL-2.0 license can be found at:
 - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -20,16 +22,16 @@ LEGION2 includes and/or distributes the following third-party software component
 Nmap is (C) 1996-2023 Insecure.Com LLC (fyodor@nmap.org).
 ```
 
-**Modifications**: LEGION2 distributes unmodified nmap binaries as downloaded from the official sources.
+**Modifications**: LEGION2 does not modify nmap source code. It invokes the nmap binary installed on the host system or obtained from official sources.
 
 ## Masscan
 
-**Version**: 1.3.2  
+**Version**: 1.3.2+ (system package or official binary)  
 **License**: AGPL-3.0 (GNU Affero General Public License v3.0)  
 **Website**: https://github.com/robertdavidgraham/masscan  
 **Source Code**: https://github.com/robertdavidgraham/masscan  
 
-**Description**: This is an Internet-scale port scanner. It can scan the entire Internet in under 6 minutes, transmitting 10 million packets per second, from a single machine.
+**Description**: Internet-scale port scanner used by LEGION2 for high-rate port sweeps in the Massmap pipeline.
 
 **License Text**: The full text of the AGPL-3.0 license can be found at:
 - https://www.gnu.org/licenses/agpl-3.0.html
@@ -40,74 +42,48 @@ Nmap is (C) 1996-2023 Insecure.Com LLC (fyodor@nmap.org).
 Copyright (c) 2013 Robert David Graham
 ```
 
-**Modifications**: LEGION2 may distribute either:
-- Unmodified masscan binaries compiled from official source code
-- Pre-built binaries obtained from official releases
+**Modifications**: LEGION2 does not modify masscan source code. It invokes the masscan binary installed on the host system or obtained from official releases.
 
 ## License Compliance
 
 ### GPL-2.0 Compliance (Nmap)
-- **Source Code Availability**: The source code for nmap is available at https://github.com/nmap/nmap
-- **Distribution Rights**: We distribute nmap under the terms of GPL-2.0
-- **Modifications**: No modifications have been made to the nmap source code
-- **License Notice**: This license notice is provided to inform users of their rights under GPL-2.0
+- **Source Code Availability**: https://github.com/nmap/nmap
+- **Distribution Rights**: Any redistribution of nmap binaries must comply with GPL-2.0
+- **Modifications**: No modifications to nmap source by LEGION2
+- **License Notice**: This notice informs users of their rights under GPL-2.0
 
 ### AGPL-3.0 Compliance (Masscan)
-- **Source Code Availability**: The source code for masscan is available at https://github.com/robertdavidgraham/masscan
-- **Network Use Clause**: Under AGPL-3.0, users who interact with masscan over a network are entitled to receive the source code
-- **Distribution Rights**: We distribute masscan under the terms of AGPL-3.0
-- **Modifications**: Any modifications (if made) would be clearly documented and source code provided
-- **License Notice**: This license notice is provided to inform users of their rights under AGPL-3.0
+- **Source Code Availability**: https://github.com/robertdavidgraham/masscan
+- **Network Use Clause**: Under AGPL-3.0, offering masscan as a network service may require source disclosure to users
+- **Distribution Rights**: Any redistribution of masscan binaries must comply with AGPL-3.0
+- **Modifications**: No modifications to masscan source by LEGION2
+- **License Notice**: This notice informs users of their rights under AGPL-3.0
 
 ## User Rights and Obligations
 
 ### For Nmap (GPL-2.0)
-Users have the right to:
-- Use the software for any purpose
-- Study and modify the source code
-- Distribute copies of the software
-- Distribute modified versions
-
-Users must:
-- Include the license and copyright notice
-- Provide source code when distributing
-- Use the same license for derivative works
+Users have the right to use, study, modify, and distribute the software. Users must include the license and copyright notice and provide source code when distributing.
 
 ### For Masscan (AGPL-3.0)
-Users have the right to:
-- Use the software for any purpose
-- Study and modify the source code
-- Distribute copies of the software
-- Distribute modified versions
-
-Users must:
-- Include the license and copyright notice
-- Provide source code when distributing or offering network services
-- Use the same license for derivative works
-- Provide source code to users who access the software over a network
+Users have the right to use, study, modify, and distribute the software. Users must include the license and copyright notice, provide source code when distributing or offering network services, and use the same license for derivative works.
 
 ## Additional Information
 
-### Binary Distribution
-LEGION2 includes pre-compiled binaries of nmap and masscan for user convenience. These binaries are:
-- Downloaded from official sources during the build process
-- Distributed in their original, unmodified form
-- Subject to the original licenses (GPL-2.0 for nmap, AGPL-3.0 for masscan)
+### Current Integration Model
+LEGION2 invokes nmap and masscan as **external system binaries** (documented in installation instructions). LEGION2 does not ship modified copies inside the application bundle unless explicitly noted in release artifacts.
 
 ### Source Code Access
-Users can obtain the source code for these tools from:
 - **Nmap**: https://github.com/nmap/nmap or https://nmap.org/download.html
 - **Masscan**: https://github.com/robertdavidgraham/masscan
 
 ### Contact Information
-If you have questions about the licensing of these third-party components, please contact:
 - For nmap: fyodor@nmap.org
 - For masscan: https://github.com/robertdavidgraham/masscan/issues
-- For LEGION2: https://github.com/yourusername/LEGION2/issues
+- For LEGION2: https://github.com/NubleX/LEGION2/issues
 
 ## Acknowledgments
 
-We thank the developers and contributors of nmap and masscan for creating these powerful network scanning tools and making them available under open source licenses. Their work enables security professionals, network administrators, and researchers worldwide to better understand and secure their networks.
+We thank the developers and contributors of nmap and masscan for creating these powerful network scanning tools. Their work enables security professionals worldwide to better understand and secure their networks.
 
 ## Disclaimer
 
@@ -115,5 +91,5 @@ LEGION2 is a separate project and is not affiliated with, endorsed by, or connec
 
 ---
 
-*Last Updated: January 2025*  
-*LEGION2 Version: 0.2.3-alpha*
+*Last Updated: June 2026*  
+*LEGION2 Version: 0.4.0*


### PR DESCRIPTION
Keep .deb and AppImage artifacts out of git (GitHub 100MB limit). Publish builds via GitHub Releases instead.